### PR TITLE
change WebIntegrationTests from DEFINED_PORT to RANDOM_PORT

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -38,3 +38,16 @@ editor:
     - "generatorName": "NewRestService"
     - "description": "A company-standard REST service"
 
+---
+kind: "operation"
+client: "atomist-bot"
+editor:
+  name: "UseRandomPort"
+  group: "satellite-of-love"
+  artifact: "rest-service-generator"
+  version: "0.11.8"
+  origin:
+    repo: "git@github.com:satellite-of-love/workflow-rugs"
+    branch: "master"
+    sha: "4de3290"
+

--- a/src/test/java/com/jessitron/SurveyOptionsWebIntegrationTests.java
+++ b/src/test/java/com/jessitron/SurveyOptionsWebIntegrationTests.java
@@ -6,26 +6,25 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = SurveyOptionsApplication.class, webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(classes = SurveyOptionsApplication.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 public class SurveyOptionsWebIntegrationTests {
 
-    private static final int PORT = 8080;
-
-    // Parameterize tests like this
-    private static final String BASE_PATH = "http://localhost:" + PORT;
+    
 
     // Use this to run tests
-    private RestTemplate restTemplate = new RestTemplate();
+    @Autowired
+    private TestRestTemplate restTemplate;
 
     @Test
     public void sampleTest() {
-        String result = restTemplate.getForObject(BASE_PATH, String.class);
+        String result = restTemplate.getForObject("/", String.class);
         System.out.println(result);
         assertTrue(result.contains("Hello"));
     }
@@ -34,7 +33,7 @@ public class SurveyOptionsWebIntegrationTests {
     public void optionsTest() {
         int count = 2; // todo: how can I use a URI template to populate this?
         int seed = 123;
-        SurveyOptions result = restTemplate.getForObject(BASE_PATH + "/surveyOptions?seed=123&count=2", SurveyOptions.class);
+        SurveyOptions result = restTemplate.getForObject("/" + "/surveyOptions?seed=123&count=2", SurveyOptions.class);
         assertEquals(count, result.getOptions().size());
         assertEquals(seed, result.getSeed());
     }


### PR DESCRIPTION
A pull request from your friendly architecture team. 
This is some information some teams have learned the hard way:
Using a random port can reduce build failures.
See: https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-testing.html#boot-features-testing-spring-boot-applications-working-with-random-ports

This automated pull request attempts to change defined ports to random ports in Web Integration tests.
Please review the changes and see whether they make sense for your project. Contact @jessitron in Slack with feedback either way.
This change is optional; take it or leave it; it probably won't hurt and might help.


Created by Atomist Editor `UseRandomPort`
```
---
kind: "operation"
client: "atomist-bot"
editor:
  name: "UseRandomPort"
  group: "satellite-of-love"
  artifact: "rest-service-generator"
  version: "0.11.8"
  origin:
    repo: "git@github.com:satellite-of-love/workflow-rugs"
    branch: "master"
    sha: "4de3290"

```